### PR TITLE
Strip linux builds to optimize space

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,9 @@ jobs:
         npm test
       env:
         CI: true
+    - name: strip linux builds
+      if: matrix.build == 'linux-gnu'
+      run: strip dist/node/*.node
     - name: Set artifact name
       shell: bash
       working-directory: dist/node


### PR DESCRIPTION
Reduces .node bundles from 1.4MB to 278KB