### PR TITLE
Build on 20.04 to fix perf regression

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
           os: macos-latest
           target: x86_64-apple-darwin
         - build: linux-gnu
-          os: ubuntu-latest
+          os: ubuntu-20.04
           target: x86_64-unknown-linux-gnu        
 
     steps:


### PR DESCRIPTION
As reported in https://github.com/lovell/highwayhash/issues/8 there was an unexpected drop in performance with the latest `highwayhasher` release. The fix is to cut releases on 20.04 instead of 18.04. What exactly caused the regression is unknown, but I'll take the win.