### PR TITLE
Remove intermediate hash result vector

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -6,12 +6,9 @@ pub fn data_to_lanes(d: &[u8]) -> [u64; 4] {
     result
 }
 
-pub fn u64_slice_to_u8(hash: &[u64]) -> Vec<u8> {
+pub fn u64_slice_to_u8(out: &mut [u8], hash: &[u64]) {
     const U64_LEN: usize = std::mem::size_of::<u64>();
-    let mut bytes = vec![0; U64_LEN * hash.len()];
-    for (&hash, out) in hash.iter().zip(bytes.chunks_exact_mut(U64_LEN)) {
+    for (&hash, out) in hash.iter().zip(out.chunks_exact_mut(U64_LEN)) {
         out.copy_from_slice(&hash.to_le_bytes())
     }
-
-    bytes
 }

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -1,5 +1,5 @@
-use highway::{HighwayBuilder, HighwayHash, Key};
 use common::{data_to_lanes, u64_slice_to_u8};
+use highway::{HighwayBuilder, HighwayHash, Key};
 use napi::{CallContext, JsBuffer, JsFunction, JsObject, JsUndefined, Property};
 use napi_derive::{js_function, module_exports};
 
@@ -52,9 +52,7 @@ fn finalize64(ctx: CallContext) -> napi::Result<JsBuffer> {
     let this: JsObject = ctx.this()?;
     let hasher: &mut HighwayBuilder = ctx.env.unwrap(&this)?;
     let res = hasher.clone().finalize64();
-    let buf = ctx
-        .env
-        .create_buffer_with_data(res.to_ne_bytes().to_vec())?;
+    let buf = ctx.env.create_buffer_copy(&res.to_le_bytes()[..])?;
     Ok(buf.into_raw())
 }
 
@@ -63,8 +61,9 @@ fn finalize128(ctx: CallContext) -> napi::Result<JsBuffer> {
     let this: JsObject = ctx.this()?;
     let hasher: &mut HighwayBuilder = ctx.env.unwrap(&this)?;
     let hash = hasher.clone().finalize128();
-    let bytes = u64_slice_to_u8(&hash);
-    let buf = ctx.env.create_buffer_with_data(bytes.to_vec())?;
+    let mut bytes = [0u8; 16];
+    u64_slice_to_u8(&mut bytes, &hash[..]);
+    let buf = ctx.env.create_buffer_copy(&bytes[..])?;
     Ok(buf.into_raw())
 }
 
@@ -73,8 +72,9 @@ fn finalize256(ctx: CallContext) -> napi::Result<JsBuffer> {
     let this: JsObject = ctx.this()?;
     let hasher: &mut HighwayBuilder = ctx.env.unwrap(&this)?;
     let hash = hasher.clone().finalize256();
-    let bytes = u64_slice_to_u8(&hash);
-    let buf = ctx.env.create_buffer_with_data(bytes.to_vec())?;
+    let mut bytes = [0u8; 32];
+    u64_slice_to_u8(&mut bytes, &hash[..]);
+    let buf = ctx.env.create_buffer_copy(&bytes[..])?;
     Ok(buf.into_raw())
 }
 

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -1,5 +1,5 @@
-use highway::{HighwayBuilder, HighwayHash, Key};
 use common::{data_to_lanes, u64_slice_to_u8};
+use highway::{HighwayBuilder, HighwayHash, Key};
 use wasm_bindgen::prelude::*;
 
 #[global_allocator]
@@ -31,17 +31,24 @@ impl WasmHighway {
     }
 
     #[wasm_bindgen]
-    pub fn finalize64(self) -> Vec<u8> {
-        self.inner.finalize64().to_le_bytes().to_vec()
+    pub fn finalize64(self) -> js_sys::Uint8Array {
+        let res = self.inner.finalize64().to_le_bytes();
+        (&res[..]).into()
     }
 
     #[wasm_bindgen]
-    pub fn finalize128(self) -> Vec<u8> {
-        u64_slice_to_u8(&self.inner.finalize128())
+    pub fn finalize128(self) -> js_sys::Uint8Array {
+        let hash = self.inner.finalize128();
+        let mut bytes = [0u8; 16];
+        u64_slice_to_u8(&mut bytes, &hash[..]);
+        (&bytes[..]).into()
     }
 
     #[wasm_bindgen]
-    pub fn finalize256(self) -> Vec<u8> {
-        u64_slice_to_u8(&self.inner.finalize256())
+    pub fn finalize256(self) -> js_sys::Uint8Array {
+        let hash = self.inner.finalize256();
+        let mut bytes = [0u8; 32];
+        u64_slice_to_u8(&mut bytes, &hash[..]);
+        (&bytes[..]).into()
     }
 }


### PR DESCRIPTION
Instead of copying to a heap allocated vector, use a stack allocated
array instead. There's no measurable performance difference.