### PR TITLE
Only run verification CI workflow on dispatch

### DIFF
--- a/.github/workflows/verifier.yml
+++ b/.github/workflows/verifier.yml
@@ -1,12 +1,7 @@
 name: Verify
 
-on:
-  pull_request:
-  push:
-    branches:
-    - master
-  schedule:
-  - cron: '00 01 * * *'
+on: 
+  workflow_dispatch:
 
 jobs:
   verify:


### PR DESCRIPTION
This is because any new APIs that are introduced and tested will break
the prior release's verification (as those APIs weren't implemented
then)