### PR TITLE
Introduce non-streaming APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,18 @@ expect(out).toEqual(expected);
 
 That's it! Now your program will use native code on nodejs and Wasm in the browser (when bundled by webpack, rollup, or any other javascript bundler that respects [the `browser` package.json spec](https://github.com/defunctzombie/package-browser-field-spec)) without any bloat!
 
+## Non-Streaming API
+
+When executing on native hardware and the data to hash is known entirely, one can use one of the non-streaming APIs that operate more efficiently than their incremental counterparts on small data.
+
+```js
+import { HighwayHash } from "highwayhasher";
+
+const keyData = Uint8Array.from(new Array(32).fill(1));
+const hasher = await HighwayHash.loadModule();
+const out = hasher.hash64(keyData, Uint8Array.from([0]));
+```
+
 ## Wasm-Only
 
 Since Wasm is cross platform, one can drop any reliance on native dependencies by opting to only use the Wasm implementation

--- a/bench/index.js
+++ b/bench/index.js
@@ -5,7 +5,7 @@ const { assert } = require("console");
 const key = Buffer.alloc(32, 1);
 
 function timeIt(name, dataLen, fn) {
-  const iterations = Math.min(Math.max(1000000 / dataLen, 5), 10000);
+  const iterations = Math.min(Math.max(1000000 / dataLen, 10), 10000);
   const start = process.hrtime.bigint();
   let res;
   for (let i = 0; i < iterations; i++) {
@@ -67,12 +67,20 @@ function timeIt(name, dataLen, fn) {
     const data = Buffer.alloc(inputs[index], 1);
 
     const nativeRes = timeIt("highwayhasher native", data.length, () => {
+      return nativeMod.hash64(key, data);
+    });
+
+    timeIt("highwayhasher native streaming", data.length, () => {
       const native = nativeMod.create(key);
       native.append(data);
       return native.finalize64();
     });
 
     const wasmRes = timeIt("highwayhasher wasm", data.length, () => {
+      return wasmMod.hash64(key, data);
+    });
+
+    timeIt("highwayhasher wasm streaming", data.length, () => {
       const wasm = wasmMod.create(key);
       wasm.append(data);
       return wasm.finalize64();

--- a/src/common.ts
+++ b/src/common.ts
@@ -1,0 +1,7 @@
+export function validKey(key: Uint8Array | null | undefined): Uint8Array {
+  if (key && key.length != 32) {
+    throw new Error("expected the key buffer to be 32 bytes long");
+  }
+
+  return key || new Uint8Array();
+}

--- a/src/model.ts
+++ b/src/model.ts
@@ -31,4 +31,19 @@ export interface HashCreator {
    * Create a highwayhasher based on the given 32 byte long buffer
    */
   create(key: Uint8Array | null | undefined): IHash;
+
+  /**
+   * return 64bit hash of data with a given key
+   */
+  hash64(key: Uint8Array | null | undefined, data: Uint8Array): Uint8Array;
+
+  /**
+   * return 128bit hash of data with a given key
+   */
+  hash128(key: Uint8Array | null | undefined, data: Uint8Array): Uint8Array;
+
+  /**
+   * return 256bit hash of data with a given key
+   */
+  hash256(key: Uint8Array | null | undefined, data: Uint8Array): Uint8Array;
 }

--- a/src/web.ts
+++ b/src/web.ts
@@ -14,6 +14,30 @@ class WasmHash extends WasmHighway implements IHash {
 export const WasmModule: HashCreator = class WasmModule {
   static create = (key: Uint8Array | null | undefined): IHash =>
     new WasmHash(key);
+  static hash64 = (
+    key: Uint8Array | null | undefined,
+    data: Uint8Array
+  ): Uint8Array => {
+    const hasher = WasmModule.create(key);
+    hasher.append(data);
+    return hasher.finalize64();
+  };
+  static hash128 = (
+    key: Uint8Array | null | undefined,
+    data: Uint8Array
+  ): Uint8Array => {
+    const hasher = WasmModule.create(key);
+    hasher.append(data);
+    return hasher.finalize128();
+  };
+  static hash256 = (
+    key: Uint8Array | null | undefined,
+    data: Uint8Array
+  ): Uint8Array => {
+    const hasher = WasmModule.create(key);
+    hasher.append(data);
+    return hasher.finalize256();
+  };
 };
 
 /**

--- a/test/hash.test.js
+++ b/test/hash.test.js
@@ -59,7 +59,7 @@ const parameters = [
 ];
 
 for (const [name, Hash] of parameters) {
-  describe(`${name} hash`, () => {
+  describe(`${name} incremental hash`, () => {
     it("load and create hash", async () => {
       const mod = await Hash.loadModule();
       const hash = mod.create();
@@ -218,6 +218,37 @@ for (const [name, Hash] of parameters) {
         32,
       ]);
       expect(out).toEqual(expected);
+    });
+  });
+}
+
+for (const [name, Hash] of parameters) {
+  describe(`${name} hash`, () => {
+    it("64bit equivalency", async () => {
+      const hash1 = await Hash.loadModule();
+      const out1 = hash1.hash64(keyData, Uint8Array.from([0]));
+      const hash2 = hash1.create(keyData);
+      hash2.append(Uint8Array.from([0]));
+      const out2 = hash2.finalize64();
+      expect(out1).toEqual(out2);
+    });
+
+    it("128bit equivalency", async () => {
+      const hash1 = await Hash.loadModule();
+      const out1 = hash1.hash128(keyData, Uint8Array.from([0]));
+      const hash2 = hash1.create(keyData);
+      hash2.append(Uint8Array.from([0]));
+      const out2 = hash2.finalize128();
+      expect(out1).toEqual(out2);
+    });
+
+    it("256bit equivalency", async () => {
+      const hash1 = await Hash.loadModule();
+      const out1 = hash1.hash256(keyData, Uint8Array.from([0]));
+      const hash2 = hash1.create(keyData);
+      hash2.append(Uint8Array.from([0]));
+      const out2 = hash2.finalize256();
+      expect(out1).toEqual(out2);
     });
   });
 }


### PR DESCRIPTION
HighwayHash is a fast enough hash function that the performance penalty
of leaving the land of JS is tangible.

To give an example, the snippet has 3 N-API calls:

```ts
function hashData64(data, hash, key) {
    const hasher = hash.create(key);
    hasher.append(data);
    return hasher.finalize64();
}
```

If we replace it with a single N-API call that initializes, hashes, and
finalizes in a single step there can be major performance benefits:

- Hashing data with a length of 1 doubled in throughput (0.17 MB/s to
0.38 MB/s)
- Even at larger input sizes (~1 MB) there can be a throughput gap of
10-15% between.

So when performance is key, one should design their API to allow users
to call methods that reduce the number of N-API calls.