### PR TITLE
Enable cross compiling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,47 +12,68 @@ jobs:
   build:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         build:
         - win-msvc
         - macos
         - linux-gnu
+        - linux-aarch64
+        - linux-armv7
         include:
         - build: win-msvc
           os: windows-latest
-          target: x86_64-pc-windows-msvc
         - build: macos
           os: macos-latest
-          target: x86_64-apple-darwin
         - build: linux-gnu
           os: ubuntu-20.04
-          target: x86_64-unknown-linux-gnu        
+        - build: linux-aarch64
+          os: ubuntu-latest
+          target: aarch64-unknown-linux-gnu
+        - build: linux-armv7
+          os: ubuntu-latest
+          target: armv7-unknown-linux-gnueabihf
 
     steps:
     - uses: actions/checkout@v1
+    - name: Use Cross
+      if: matrix.target != ''
+      run: |
+        cargo install cross
+        echo "CARGO=cross" >> $GITHUB_ENV
+        echo "TARGET=${{ matrix.target }}" >> $GITHUB_ENV
     - name: Use Node
       uses: actions/setup-node@v1
       with:
         node-version: '12.x'
     - name: Install wasm-pack
       run:  curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh 
-    - name: npm install, build, and test
+    - name: npm install & build
+      shell: bash
       run: |
         npm install
-        npm run build --if-present
-        npm test
-      env:
-        CI: true
+        npm run build:web
+        npm run build:native -- ${TARGET:+--target "$TARGET"}
+        npm run build
+    - name: npm test
+      if: matrix.target == ''
+      shell: bash
+      run: npm test
     - name: browser test
       working-directory: ./e2e
+      if: matrix.target == ''
       run: |
         npm install
         npm test
-      env:
-        CI: true
     - name: strip linux builds
       if: matrix.build == 'linux-gnu'
       run: strip dist/node/*.node
+    - name: strip linux-aarch64 builds
+      if: matrix.build == 'linux-aarch64'
+      run: sudo apt-get install binutils-aarch64-linux-gnu && aarch64-linux-gnu-strip dist/node/*.node
+    - name: strip linux-armv7 builds
+      if: matrix.build == 'linux-armv7'
+      run: sudo apt-get install binutils-arm-linux-gnueabihf && arm-linux-gnueabihf-strip dist/node/*.node
     - name: Set artifact name
       shell: bash
       working-directory: dist/node

--- a/assets/build-native.sh
+++ b/assets/build-native.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+${CARGO:-cargo} build --release "$@"

--- a/assets/download-releases.sh
+++ b/assets/download-releases.sh
@@ -12,6 +12,8 @@ download_version() {
     curl -o "../dist/node/$1" -L "$RELEASE_URL/$1"
 }
 
-download_version "highwayhasher.linux-x64-gnu.node"
-download_version "highwayhasher.win32-x64-msvc.node"
-download_version "highwayhasher.darwin-x64.node"
+download_version "highwayhasher.x86_64-unknown-linux-gnu.node"
+download_version "highwayhasher.aarch64-unknown-linux-gnu.node"
+download_version "highwayhasher.armv7-unknown-linux-gnueabihf.node"
+download_version "highwayhasher.x86_64-apple-darwin.node"
+download_version "highwayhasher.x86_64-pc-windows-msvc.node"

--- a/package.json
+++ b/package.json
@@ -13,27 +13,17 @@
     "./dist/node/es/index_node.js": "./dist/browser/es/index_browser.js"
   },
   "types": "./dist/browser/es/index_browser.d.ts",
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "scripts": {
-    "build": "npm run build:native && npm run build:web && rm -rf dist/ && rollup -c && cp ./native/*.node ./dist/node/.",
-    "build:native": "cd native && napi build -c ../package.json --platform --release",
+    "build": "rm -rf dist/ && rollup -c",
+    "build:native": "bash ./assets/build-native.sh",
     "build:web": "wasm-pack build -t web --out-dir ../src/web web",
-    "pretest": "npm run build",
     "test": "npm run test:native && npm run test:types",
     "test:types": "tsc --noEmit test/usage.ts",
     "test:native": "jest",
-    "prepublishOnly": "./assets/download-releases.sh && npm run test:native"
-  },
-  "os": [
-    "darwin",
-    "linux",
-    "win32"
-  ],
-  "napi": {
-    "name": "highwayhasher",
-    "triples": {
-      "defaults": true
-    }
+    "prepublishOnly": "./assets/download-releases.sh && npm test"
   },
   "jest": {
     "testRegex": "./test/.*.js$",
@@ -49,7 +39,6 @@
   "license": "MIT",
   "dependencies": {},
   "devDependencies": {
-    "@napi-rs/cli": "^1.0.0",
     "@rollup/plugin-typescript": "^8.1.0",
     "@rollup/plugin-wasm": "^5.1.2",
     "jest": "^26.6.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -2,6 +2,8 @@ import { wasm } from "@rollup/plugin-wasm";
 import typescript from "@rollup/plugin-typescript";
 import pkg from "./package.json";
 import path from "path";
+import { execSync } from 'child_process'
+import os from "os";
 import fs from "fs";
 
 const rolls = (fmt, platform) => ({
@@ -29,10 +31,39 @@ const rolls = (fmt, platform) => ({
           path.resolve(`src/web/highwayhasher_web.js`),
           data.replace("import.meta.url", "input")
         );
+
+        if (fmt === "cjs" && platform === "node") {
+          distributeSharedNode()
+        }
       },
     },
   ],
 });
+
+const releaseArtifact = (app) => {
+  switch (os.platform()) {
+    case 'darwin':
+      return `lib${app}.dylib`;
+    case 'win32':
+      return `${app}.dll`;
+    default:
+      return `lib${app}.so`;
+  }
+}
+
+const defaultTriple = () => {
+  const out = execSync("rustup show active-toolchain").toString("utf-8");
+  const prec = out.split(' ', 2)[0];
+  return prec.substring(prec.indexOf("-") + 1);
+}
+
+const distributeSharedNode = () => {
+  const artifact = releaseArtifact(pkg.name);
+  const input = path.resolve(__dirname, `target/${process.env.TARGET || ""}/release/${artifact}`);
+  const output = path.resolve(__dirname, `dist/node/${pkg.name}-${process.env.TARGET || defaultTriple()}.node`);
+  fs.mkdirSync(path.resolve(__dirname, "dist/node"), { recursive: true });
+  fs.copyFileSync(input, output);
+}
 
 export default [
   rolls("cjs", "node"),

--- a/src/native.ts
+++ b/src/native.ts
@@ -1,27 +1,32 @@
 import type { HashCreator, IHash } from "./model";
-import { platform, arch } from "os";
+import os from "os";
 import { validKey } from "./common";
 
-const getAbi = (platform: string): string => {
-  switch (platform) {
-    case "linux":
-      return "-gnu";
-    case "win32":
-      return "-msvc";
-    default:
-      return "";
+const getTriple = (): string => {
+  const platform = os.platform();
+  const arch = os.arch();
+  if (platform === "linux" && arch === "x64") {
+    return "x86_64-unknown-linux-gnu";
+  } else if (platform === "linux" && arch === "arm64") {
+    return "aarch64-unknown-linux-gnu";
+  } else if (platform === "linux" && arch === "arm") {
+    return "armv7-unknown-linux-gnueabihf";
+  } else if (platform === "darwin" && arch === "x64") {
+    return "x86_64-apple-darwin";
+  } else if (platform === "win32" && arch == "x64") {
+    return "x86_64-pc-windows-msvc";
+  } else {
+    throw new Error(`unknown platform-arch: ${platform}-${arch}`)
   }
 };
 
 const MODULE_NAME = "highwayhasher";
-const PLATFORM = platform();
-const ABI = getAbi(PLATFORM);
 const {
   createHighwayClass,
   hash64: internalHash64,
   hash128: internalHash128,
   hash256: internalHash256,
-} = require(`../${MODULE_NAME}.${PLATFORM}-${arch()}${ABI}.node`);
+} = require(`../${MODULE_NAME}-${getTriple()}.node`);
 const InternalHasher = createHighwayClass();
 
 class NativeHash implements IHash {


### PR DESCRIPTION
This introduces the ability to cross compile the highwayhasher package to other architectures than what CI natively supports. This is done via Cross. This is in stark contrast to how other napi-rs packages are cross compiled. Truthfully I like the cross approach better. It's what I know and it seems more straightforward.

Closes #1