### PR TITLE
Simplify contributing workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,11 +54,11 @@ jobs:
         npm install
         npm run build:web
         npm run build:native -- ${TARGET:+--target "$TARGET"}
-        npm run build
+        npm run build:bundle
     - name: npm test
       if: matrix.target == ''
       shell: bash
-      run: npm test
+      run: npm run test:inplace
     - name: browser test
       working-directory: ./e2e
       if: matrix.target == ''

--- a/package.json
+++ b/package.json
@@ -17,10 +17,12 @@
     "dist"
   ],
   "scripts": {
-    "build": "rm -rf dist/ && rollup -c",
+    "build": "rm -rf dist/ && npm run build:web && npm run build:native && npm run build:bundle",
     "build:native": "bash ./assets/build-native.sh",
     "build:web": "wasm-pack build -t web --out-dir ../src/web web",
-    "test": "npm run test:native && npm run test:types",
+    "build:bundle": "rollup -c",
+    "test": "npm run build && npm run test:inplace",
+    "test:inplace": "npm run test:native && npm run test:types",
     "test:types": "tsc --noEmit test/usage.ts",
     "test:native": "jest",
     "prepublishOnly": "./assets/download-releases.sh && npm test"


### PR DESCRIPTION
This PR enables one to get up and contributing with:

```
npm install
npm test
```

Instead of:

```
npm install
npm run build:web
npm run build:native
npm run build
npm test
```

This should make such a project more approachable.