### PR TITLE
Use simple JS in browser tests to fix bundle errors

### DIFF
--- a/test/hash.test.js
+++ b/test/hash.test.js
@@ -58,7 +58,9 @@ const parameters = [
   ["wasm", WasmHighwayHash],
 ];
 
-for (const [name, Hash] of parameters) {
+for (let i = 0; i < parameters.length; i++) {
+  const name = parameters[i][0];
+  const Hash = parameters[i][1];
   describe(`${name} incremental hash`, () => {
     it("load and create hash", async () => {
       const mod = await Hash.loadModule();
@@ -222,7 +224,9 @@ for (const [name, Hash] of parameters) {
   });
 }
 
-for (const [name, Hash] of parameters) {
+for (let i = 0; i < parameters.length; i++) {
+  const name = parameters[i][0];
+  const Hash = parameters[i][1];
   describe(`${name} hash`, () => {
     it("64bit equivalency", async () => {
       const hash1 = await Hash.loadModule();


### PR DESCRIPTION
For the past month the browser tests have been failing with the
following error:

```
Can't resolve 'core-js/modules/web.dom.iterable.js'
```

I'm not sure what precipated this change as CI all of a sudden starting
failing without any code changes.

Searching on the web was not fruitful as the peddled solutions involved
installing `core-js` (2 or 3) and neither worked.

What is interesting, is that using a plain for-loop over iterators and
desctructuring fixed the issue.