### PR TITLE
Add SIMD Wasm implementation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        node: [12, 16]
         build:
         - win-msvc
         - macos
@@ -54,7 +55,7 @@ jobs:
     - name: Use Node
       uses: actions/setup-node@v1
       with:
-        node-version: '12.x'
+        node-version: ${{ matrix.node }}
     - name: Install wasm-pack
       run:  curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh 
     - name: npm install & build
@@ -62,6 +63,7 @@ jobs:
       run: |
         npm install
         npm run build:web
+        RUSTFLAGS='-C target-feature=+simd128' wasm-pack build -t web --out-dir ../src/web-simd web
         npm run build:native -- ${TARGET:+--target "$TARGET"}
         npm run build:bundle
     - name: npm test

--- a/.github/workflows/verifier.yml
+++ b/.github/workflows/verifier.yml
@@ -8,24 +8,15 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        build:
-        - win
-        - macos
-        - linux
-        include:
-        - build: win
-          os: windows-latest
-        - build: macos
-          os: macos-latest
-        - build: linux
-          os: ubuntu-latest
+        node: [12, 16]
+        os: [windows-latest, macos-latest, ubuntu-latest]
 
     steps:
     - uses: actions/checkout@v1
     - name: Use Node
       uses: actions/setup-node@v1
       with:
-        node-version: '12.x'
+        node-version: ${{ matrix.node }}
     - name: verifier test
       working-directory: ./verifier
       run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,9 +26,9 @@ version = "0.1.0"
 
 [[package]]
 name = "highway"
-version = "0.6.4"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3461b968f695ca312b968503261f5a345de0f02a39dbaa3021f20d53b426395d"
+checksum = "a310093553e2397bd2936564960446b23233864bbffee554ec5847572e2dfd93"
 
 [[package]]
 name = "highwayhasher"

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ HighwayHasher is JS bindings to the [Rust implementation](https://github.com/nic
 ## Features
 
 - ✔ Isomorphic: Run on node and in the browser with the same API
-- ✔ Fast: Generate hashes at over 700 MB/s when running in web assembly
+- ✔ Fast: Generate hashes at over 2 GB/s when running on SIMD enabled web assembly
 - ✔ Faster: Generate hashes at over 8 GB/s when running on native hardware
 - ✔ Self-contained: Zero runtime dependencies
 - ✔ Accessible: Prebuilt native modules means no build dependencies

--- a/bench/README.md
+++ b/bench/README.md
@@ -6,23 +6,8 @@ To run benchmarks:
 cd ..
 npm install
 npm run build
+npm run optimize && npm run bulid:bundle
 cd bench
 npm install
 node index.js
 ```
-
-After running you will see output like:
-
-```
-hashing data of size: 10000000
-highwayhasher native 1.32ms
-highwayhasher wasm 15.49ms
-highwayhash (3rd party) 1.29ms
-
-hashing data of size: 100000000
-highwayhasher native 12.06ms
-highwayhasher wasm 135.51ms
-highwayhash (3rd party) 13.14ms
-```
-
-Here you can see how Wasm compares to the native implementations (much slower but can still be fast enough for many use cases) and that both native implementations are within margin of error.

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 crate-type = ["cdylib"]
 
 [dependencies]
-highway = "0.6"
+highway = "0.7"
 napi = "1"
 napi-derive = "1"
 common = { path = "../common" }

--- a/package.json
+++ b/package.json
@@ -17,15 +17,17 @@
     "dist"
   ],
   "scripts": {
-    "build": "rm -rf dist/ && npm run build:web && npm run build:native && npm run build:bundle",
+    "build": "rm -rf dist/ && npm run build:web && npm run build:web-simd && npm run build:native && npm run build:bundle",
     "build:native": "bash ./assets/build-native.sh",
     "build:web": "wasm-pack build -t web --out-dir ../src/web web",
+    "build:web-simd": "RUSTFLAGS='-C target-feature=+simd128' wasm-pack build -t web --out-dir ../src/web-simd web",
     "build:bundle": "rollup -c",
+    "optimize": "wasm-opt -Os src/web/highwayhasher_web_bg.wasm -o tmp.wasm && mv tmp.wasm src/web/highwayhasher_web_bg.wasm && wasm-opt -Os src/web-simd/highwayhasher_web_bg.wasm -o tmp.wasm && mv tmp.wasm src/web-simd/highwayhasher_web_bg.wasm",
     "test": "npm run build && npm run test:inplace",
     "test:inplace": "npm run test:native && npm run test:types",
     "test:types": "tsc --noEmit test/usage.ts",
     "test:native": "jest",
-    "prepublishOnly": "./assets/download-releases.sh && npm test"
+    "prepublishOnly": "./assets/download-releases.sh && npm test && npm run optimize && npm run build:bundle"
   },
   "jest": {
     "testRegex": "./test/.*.js$",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -22,16 +22,16 @@ const rolls = (fmt, platform) => ({
       generateBundle() {
         // Remove the `import` bundler directive that wasm-bindgen spits out as webpack < 5
         // doesn't understand that directive
-        const data = fs.readFileSync(
-          path.resolve(`src/web/highwayhasher_web.js`),
-          "utf8"
-        );
+        const removeImport = (fp) => {
+          const data = fs.readFileSync(path.resolve(fp), "utf8");
+          fs.writeFileSync(
+            path.resolve(fp),
+            data.replace("import.meta.url", "input")
+          );
+        };
 
-        fs.writeFileSync(
-          path.resolve(`src/web/highwayhasher_web.js`),
-          data.replace("import.meta.url", "input")
-        );
-
+        removeImport("src/web/highwayhasher_web.js");
+        removeImport("src/web-simd/highwayhasher_web.js");
         if (fmt === "cjs" && platform === "node") {
           distributeSharedNode();
         }

--- a/src/index_browser.ts
+++ b/src/index_browser.ts
@@ -1,3 +1,3 @@
-export type { IHash, HashCreator } from "./model";
-export { WasmHighwayHash } from "./web";
+export type { IHash, HashCreator, HighwayLoadOptions } from "./model";
+export { WasmHighwayHash, hasSimd as hasWasmSimd } from "./web";
 export { WasmHighwayHash as HighwayHash } from "./web";

--- a/src/index_node.ts
+++ b/src/index_node.ts
@@ -1,3 +1,3 @@
-export type { IHash, HashCreator } from "./model";
-export { WasmHighwayHash } from "./web";
+export type { IHash, HashCreator, HighwayLoadOptions } from "./model";
+export { WasmHighwayHash, hasSimd as hasWasmSimd } from "./web";
 export { NativeHighwayHash as HighwayHash } from "./native";

--- a/src/model.ts
+++ b/src/model.ts
@@ -47,3 +47,16 @@ export interface HashCreator {
    */
   hash256(key: Uint8Array | null | undefined, data: Uint8Array): Uint8Array;
 }
+
+/**
+ * Customize how highway modules are loaded
+ */
+export interface HighwayLoadOptions {
+  /**
+   * Execute HighwayHash with SIMD instructions. This option is only
+   * applicable in a Wasm environment, as native hardware will detect SIMD at
+   * runtime. `highwayhasher` will detect if Wasm SIMD is enabled if this
+   * option is not set, so this option is used to override the heuristic.
+   */
+  simd?: boolean;
+}

--- a/src/native.ts
+++ b/src/native.ts
@@ -1,4 +1,4 @@
-import type { HashCreator, IHash } from "./model";
+import type { HashCreator, HighwayLoadOptions, IHash } from "./model";
 import os from "os";
 import { validKey } from "./common";
 
@@ -60,7 +60,9 @@ export const NativeModule: HashCreator = class NativeModule {
 };
 
 export class NativeHighwayHash {
-  static async loadModule(): Promise<HashCreator> {
+  static async loadModule(
+    _options?: Partial<HighwayLoadOptions>
+  ): Promise<HashCreator> {
     if (native === undefined) {
       native = require(`../${MODULE_NAME}-${getTriple()}.node`);
       InternalHasher = native.createHighwayClass();
@@ -69,7 +71,10 @@ export class NativeHighwayHash {
     return NativeModule;
   }
 
-  static async load(key: Uint8Array | null | undefined): Promise<IHash> {
+  static async load(
+    key: Uint8Array | null | undefined,
+    _options?: Partial<HighwayLoadOptions>
+  ): Promise<IHash> {
     return new NativeHash(key);
   }
 }

--- a/src/web.ts
+++ b/src/web.ts
@@ -1,65 +1,117 @@
-import type { HashCreator, IHash } from "./model";
+import type { HashCreator, HighwayLoadOptions, IHash } from "./model";
+import { validKey } from "./common";
 import init, { WasmHighway } from "./web/highwayhasher_web";
+import simdInit, {
+  WasmHighway as WasmSimdHighway,
+} from "./web-simd/highwayhasher_web";
 import wasm from "./web/highwayhasher_web_bg.wasm";
+import wasmSimd from "./web-simd/highwayhasher_web_bg.wasm";
 
 class WasmHash extends WasmHighway implements IHash {
   constructor(key: Uint8Array | null | undefined) {
-    if (key && key.length != 32) {
-      throw new Error("expected the key buffer to be 32 bytes long");
-    }
-    super(key || new Uint8Array());
+    super(validKey(key));
   }
 }
 
-export const WasmModule: HashCreator = class WasmModule {
-  static create = (key: Uint8Array | null | undefined): IHash =>
-    new WasmHash(key);
-  static hash64 = (
-    key: Uint8Array | null | undefined,
-    data: Uint8Array
-  ): Uint8Array => {
-    const hasher = WasmModule.create(key);
-    hasher.append(data);
-    return hasher.finalize64();
-  };
-  static hash128 = (
-    key: Uint8Array | null | undefined,
-    data: Uint8Array
-  ): Uint8Array => {
-    const hasher = WasmModule.create(key);
-    hasher.append(data);
-    return hasher.finalize128();
-  };
-  static hash256 = (
-    key: Uint8Array | null | undefined,
-    data: Uint8Array
-  ): Uint8Array => {
-    const hasher = WasmModule.create(key);
-    hasher.append(data);
-    return hasher.finalize256();
+class WasmSimdHash extends WasmSimdHighway implements IHash {
+  constructor(key: Uint8Array | null | undefined) {
+    super(validKey(key));
+  }
+}
+
+const createModule = (
+  create: (key: Uint8Array | null | undefined) => IHash
+): HashCreator => {
+  return {
+    create,
+    hash64: (
+      key: Uint8Array | null | undefined,
+      data: Uint8Array
+    ): Uint8Array => {
+      const hasher = create(key);
+      hasher.append(data);
+      return hasher.finalize64();
+    },
+
+    hash128: (
+      key: Uint8Array | null | undefined,
+      data: Uint8Array
+    ): Uint8Array => {
+      const hasher = create(key);
+      hasher.append(data);
+      return hasher.finalize128();
+    },
+
+    hash256: (
+      key: Uint8Array | null | undefined,
+      data: Uint8Array
+    ): Uint8Array => {
+      const hasher = create(key);
+      hasher.append(data);
+      return hasher.finalize256();
+    },
   };
 };
+
+export const WasmModule = createModule((key) => new WasmHash(key));
+export const WasmSimdModule = createModule((key) => new WasmSimdHash(key));
 
 /**
  * A Highway hasher implemented in Web assembly.
  */
 export class WasmHighwayHash {
-  static async loadModule(): Promise<HashCreator> {
-    await loadWasm();
-    return WasmModule;
+  static async loadModule(
+    options?: Partial<HighwayLoadOptions>
+  ): Promise<HashCreator> {
+    const useSimd = options?.simd ?? hasSimd();
+    if (!useSimd) {
+      await loadWasm();
+      return WasmModule;
+    } else {
+      await loadWasmSimd();
+      return WasmSimdModule;
+    }
   }
 
-  static async load(key: Uint8Array | null | undefined): Promise<IHash> {
-    await loadWasm();
-    return new WasmHash(key);
+  static async load(
+    key: Uint8Array | null | undefined,
+    options?: Partial<HighwayLoadOptions>
+  ): Promise<IHash> {
+    const module = await WasmHighwayHash.loadModule(options);
+    return module.create(key);
   }
 }
 
-let wasm_initialized = false;
-const loadWasm = async () => {
-  if (!wasm_initialized) {
+let wasmInitialized = false;
+let wasmSimdInitialized = false;
+const loadWasmSimd = async () => {
+  if (!wasmSimdInitialized) {
     // @ts-ignore
-    await init(wasm());
-    wasm_initialized = true;
+    await simdInit(wasmSimd());
+    wasmSimdInitialized = true;
   }
 };
+
+const loadWasm = async () => {
+  if (!wasmInitialized) {
+    // @ts-ignore
+    await init(wasm());
+    wasmInitialized = true;
+  }
+};
+
+// Extracted from the compiled file of:
+// https://github.com/GoogleChromeLabs/wasm-feature-detect/blob/40269813c83f7e9ff370afc92cde3cc0456c557e/src/detectors/simd/module.wat
+//
+// Changes:
+//  - Validation is cached so it needs to only run once
+//  - There's no need to mark as async
+let simdEnabled: boolean | undefined;
+export const hasSimd = () =>
+  simdEnabled ??
+  (simdEnabled = WebAssembly.validate(
+    new Uint8Array([
+      0, 97, 115, 109, 1, 0, 0, 0, 1, 5, 1, 96, 0, 1, 123, 3, 2, 1, 0, 10, 10,
+      1, 8, 0, 65, 0, 253, 15, 253, 98, 11,
+    ])
+  ));

--- a/test/hash.test.js
+++ b/test/hash.test.js
@@ -1,4 +1,4 @@
-const { HighwayHash, WasmHighwayHash } = require("..");
+const { HighwayHash, WasmHighwayHash, hasWasmSimd } = require("..");
 
 // ref: https://github.com/iliakan/detect-node
 function isNode() {
@@ -137,4 +137,23 @@ for (let i = 0; i < parameters.length; i++) {
       expect(out1).toEqual(out2);
     });
   });
+}
+
+if (!hasWasmSimd() && isNode()) {
+  // Seemingly can only catch this on node.js
+  it("should throw on Wasm SIMD forced", async () => {
+    try {
+      await WasmHighwayHash.loadModule({ simd: true });
+      fail("Should have thrown exception");
+    } catch (e) {
+    }
+  })
+} else if (hasWasmSimd()) {
+  it("should hash with Wasm SIMD forced", async () => {
+    const mod = await WasmHighwayHash.loadModule({ simd: true });
+    const hash = mod.create();
+    let out = hash.finalize64();
+    let expected = Uint8Array.from([105, 68, 213, 185, 117, 218, 53, 112]);
+    expect(out).toEqual(expected);
+  })
 }

--- a/test/usage.ts
+++ b/test/usage.ts
@@ -7,7 +7,7 @@ const keyData = Uint8Array.from([
 ]);
 
 (async function () {
-  const hasher: IHash = await HighwayHash.load(keyData);
+  const hasher: IHash = await HighwayHash.load(keyData, { simd: true });
   hasher.append(Uint8Array.from([0]));
   const out: Uint8Array = hasher.finalize64();
   console.log(out);
@@ -22,4 +22,6 @@ const keyData = Uint8Array.from([
   hasher3.append(Uint8Array.from([0]));
   const out3: Uint8Array = hasher3.finalize64();
   console.log(out3);
+
+  await WasmHighwayHash.loadModule({ simd: true });
 })();

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -10,10 +10,9 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 wasm-bindgen = "0.2"
 js-sys = "0.3"
-highway = "0.6"
+highway = { version = "0.7", default-features = false }
 wee_alloc = "0.4"
 common = { path = "../common" }
 
-# https://github.com/rustwasm/wasm-pack/issues/886#issuecomment-667669802
 [package.metadata.wasm-pack.profile.release]
-wasm-opt = ["-Os", "--enable-mutable-globals"]
+wasm-opt = false

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -1,5 +1,5 @@
 use common::{data_to_lanes, u64_slice_to_u8};
-use highway::{HighwayBuilder, HighwayHash, Key};
+use highway::{HighwayHash, HighwayHasher, Key};
 use wasm_bindgen::prelude::*;
 
 #[global_allocator]
@@ -7,7 +7,7 @@ static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
 
 #[wasm_bindgen]
 pub struct WasmHighway {
-    inner: HighwayBuilder,
+    inner: HighwayHasher,
 }
 
 #[wasm_bindgen]
@@ -20,8 +20,9 @@ impl WasmHighway {
         } else {
             Key(data_to_lanes(key_data))
         };
+
         WasmHighway {
-            inner: HighwayBuilder::new(key),
+            inner: HighwayHasher::new(key)
         }
     }
 


### PR DESCRIPTION
With the underlying rust highwayhash implementation now supporting a
Wasm SIMD implementation, we dynamically detect if the current Wasm
environment supports SIMD by calling an inlined version of
[`wasm-feature-detect`][0]

Wasm users should expect up to 3x performance increase at payloads above
10,000 bytes.

The only downside to this is that the JS bundle is now twice as large as
both Wasm (SIMD enabled and not) need to be included.

[0]: https://github.com/GoogleChromeLabs/wasm-feature-detect