### PR TITLE
Fix HighwayHash.load on native platforms

### DIFF
--- a/src/main/native.ts
+++ b/src/main/native.ts
@@ -73,8 +73,9 @@ export class NativeHighwayHash {
 
   static async load(
     key: Uint8Array | null | undefined,
-    _options?: Partial<HighwayLoadOptions>
+    options?: Partial<HighwayLoadOptions>
   ): Promise<IHash> {
-    return new NativeHash(key);
+    const mod = await NativeHighwayHash.loadModule(options);
+    return mod.create(key);
   }
 }

--- a/tests/unit/hash.test.js
+++ b/tests/unit/hash.test.js
@@ -32,16 +32,16 @@ for (let i = 0; i < parameters.length; i++) {
   const name = parameters[i][0];
   const Hash = parameters[i][1];
   describe(`${name} incremental hash`, () => {
-    it("load and create hash", async () => {
-      const mod = await Hash.loadModule();
-      const hash = mod.create();
+    it("keyless and dataless 64bit", async () => {
+      const hash = await Hash.load();
       let out = hash.finalize64();
       let expected = Uint8Array.from([105, 68, 213, 185, 117, 218, 53, 112]);
       expect(out).toEqual(expected);
     });
 
-    it("keyless and dataless 64bit", async () => {
-      const hash = await Hash.load();
+    it("load and create hash", async () => {
+      const mod = await Hash.loadModule();
+      const hash = mod.create();
       let out = hash.finalize64();
       let expected = Uint8Array.from([105, 68, 213, 185, 117, 218, 53, 112]);
       expect(out).toEqual(expected);


### PR DESCRIPTION
The native module was assumed to have been loaded previously