### PR TITLE
Bump node version to 14 on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [12, 16]
+        node: [14, 16]
         build:
         - win-msvc
         - macos


### PR DESCRIPTION
This seems to fix flaky node 12 tests introduced in
https://github.com/nickbabcock/highwayhasher/pull/33

Node 12 will be supported by happenstance from now on