### PR TITLE
Allow control over Wasm instantiation

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -33,7 +33,20 @@ const rolls = (fmt, platform) => ({
         removeImport("src/main/wasm/highwayhasher_wasm.js");
         removeImport("src/main/wasm-simd/highwayhasher_wasm.js");
         if (fmt === "cjs" && platform === "node") {
+          fs.mkdirSync(path.resolve(__dirname, "dist/node"), { recursive: true });
           distributeSharedNode();
+
+          // Copy over our wasm bundles to each out directory as a known name to
+          // downstream users so that they can access the wasm payloads directly
+          // as needed.
+          fs.copyFileSync(
+            "src/main/wasm/highwayhasher_wasm_bg.wasm",
+            "dist/highwayhasher_wasm_bg.wasm"
+          );
+          fs.copyFileSync(
+            "src/main/wasm-simd/highwayhasher_wasm_bg.wasm",
+            "dist/highwayhasher_wasm_simd_bg.wasm"
+          );
         }
       },
     },
@@ -67,7 +80,6 @@ const distributeSharedNode = () => {
     __dirname,
     `dist/node/${pkg.name}-${process.env.TARGET || defaultTriple()}.node`
   );
-  fs.mkdirSync(path.resolve(__dirname, "dist/node"), { recursive: true });
   fs.copyFileSync(input, output);
 };
 

--- a/src/main/model.ts
+++ b/src/main/model.ts
@@ -49,6 +49,24 @@ export interface HashCreator {
 }
 
 /**
+ * Parameters able to instantiate the Wasm hasher
+ */
+export type InitInput =
+  | RequestInfo
+  | URL
+  | Response
+  | BufferSource
+  | WebAssembly.Module;
+
+export type WasmInput = {
+  /** parameter that describes how to instantiate the non-SIMD enabled Wasm */
+  sisd: InitInput;
+
+  /** parameter that describes how to instantiate the SIMD enabled Wasm */
+  simd: InitInput;
+};
+
+/**
  * Customize how highway modules are loaded
  */
 export interface HighwayLoadOptions {
@@ -59,4 +77,12 @@ export interface HighwayLoadOptions {
    * option is not set, so this option is used to override the heuristic.
    */
   simd?: boolean;
+
+  /**
+   * Controls how the Wasm module is instantiated. This option is only
+   * applicable in browser environments or for users that opt to use the Wasm
+   * hasher. If the `wasm` option is given a single instantiation parameter,
+   * there is no SIMD check performed.
+   */
+  wasm?: WasmInput | InitInput;
 }

--- a/tests/unit/usage.ts
+++ b/tests/unit/usage.ts
@@ -23,7 +23,20 @@ const keyData = Uint8Array.from([
   const out3: Uint8Array = hasher3.finalize64();
   console.log(out3);
 
-  const hasher4 = mod.create();
+  const _hasher4 = mod.create();
+  HighwayHash.resetModule();
 
   await WasmHighwayHash.loadModule({ simd: true });
+
+  const wasmModule = null as unknown as WebAssembly.Module;
+  await WasmHighwayHash.loadModule({
+    wasm: wasmModule,
+  });
+
+  await WasmHighwayHash.loadModule({
+    wasm: {
+      sisd: wasmModule,
+      simd: wasmModule,
+    },
+  });
 })();


### PR DESCRIPTION
A new option has been introduced for the highwayhasher instantiation
that allows downstream users to control how the Wasm hasher is
instantiated. One can now pass in a URL to fetch, buffers, or an already
compiled wasm module.

The main impetus is that environments like cloudflare workers do not
allow Wasm compilation, but do support importing wasm files that will be
pre-compiled into `WebAssembly.Module`.