### PR TITLE
Avoid rust dynamic allocations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,12 +25,6 @@ checksum = "c1ad822118d20d2c234f427000d5acc36eabe1e29a348c89b63dd60b13f28e5d"
 
 [[package]]
 name = "cfg-if"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
-
-[[package]]
-name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
@@ -57,9 +51,9 @@ dependencies = [
 
 [[package]]
 name = "highway"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3688f13e7735ae5ca93edc490f6c5885b77d473255bc1fed92b9c805f972bf94"
+checksum = "1489f81ead4b71a09ddeab6850c0356c0932587637d753f21ee1010ab875b013"
 
 [[package]]
 name = "highwayhasher"
@@ -78,25 +72,8 @@ version = "0.1.0"
 dependencies = [
  "common",
  "highway",
- "js-sys",
- "wasm-bindgen",
- "wee_alloc",
-]
-
-[[package]]
-name = "js-sys"
-version = "0.3.60"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49409df3e3bf0856b916e2ceaca09ee28e6871cf7d9ce97a692cacfdb2a25a47"
-dependencies = [
  "wasm-bindgen",
 ]
-
-[[package]]
-name = "libc"
-version = "0.2.133"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0f80d65747a3e43d1596c7c5492d95d5edddaabd45a7fcdb02b95f644164966"
 
 [[package]]
 name = "libloading"
@@ -104,7 +81,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efbc0f03f9a775e9f6aed295c6a1ba2253c5757a9e03d55c6caa46a681abcddd"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "winapi",
 ]
 
@@ -114,7 +91,7 @@ version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
@@ -122,12 +99,6 @@ name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
-
-[[package]]
-name = "memory_units"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8452105ba047068f40ff7093dd1d9da90898e63dd61736462e9cdda6a90ad3c3"
 
 [[package]]
 name = "napi"
@@ -257,7 +228,7 @@ version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaf9f5aceeec8be17c128b2e93e031fb8a4d469bb9c4ae2d7dc1888b26887268"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "wasm-bindgen-macro",
 ]
 
@@ -304,18 +275,6 @@ name = "wasm-bindgen-shared"
 version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
-
-[[package]]
-name = "wee_alloc"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbb3b5a6b2bb17cb6ad44a2e68a43e8d2722c997da10e928665c72ec6c0a0b8e"
-dependencies = [
- "cfg-if 0.1.10",
- "libc",
- "memory_units",
- "winapi",
-]
 
 [[package]]
 name = "winapi"

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ HighwayHasher is JS bindings to the [Rust implementation](https://github.com/nic
 - ✔ Accessible: Prebuilt native modules means no build dependencies
 - ✔ Completeness: Generate 64, 128, and 256bit hashes
 - ✔ Incremental: Hash data incrementally
-- ✔ Small: Less than 20kB when minified and gzipped (or 10KB when using the [slim entrypoint](#slim-module))
+- ✔ Small: Less than 10 KB when minified and gzipped (or 5 KB when using the [slim entrypoint](#slim-module))
 
 ## Install
 
@@ -72,6 +72,8 @@ let out = hash.finalize64();
 let expected = Uint8Array.from([120, 221, 205, 199, 170, 67, 171, 126]);
 expect(out).toEqual(expected);
 ```
+
+Do note that there is a max number to concurrent Wasm hashers. It is currently 292 instances. If this is believed to be a significant limitation, open an issue so we can discuss it!   
 
 ## Slim Module
 

--- a/src/native/Cargo.toml
+++ b/src/native/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 crate-type = ["cdylib"]
 
 [dependencies]
-highway = "0.8"
+highway = "0.8.1"
 napi = "2"
 napi-derive = "2"
 common = { path = "../common" }

--- a/src/wasm/Cargo.toml
+++ b/src/wasm/Cargo.toml
@@ -9,9 +9,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 wasm-bindgen = "0.2"
-js-sys = "0.3"
-highway = { version = "0.8", default-features = false }
-wee_alloc = "0.4"
+highway = { version = "0.8.1", default-features = false }
 common = { path = "../common" }
 
 [package.metadata.wasm-pack.profile.release]

--- a/tests/unit/hash.test.ts
+++ b/tests/unit/hash.test.ts
@@ -108,6 +108,18 @@ for (let i = 0; i < parameters.length; i++) {
       ]);
       expect(out).toEqual(expected);
     });
+
+    it("interleaved hashing", async () => {
+      const hash1 = await Hash.load();
+      const hash2 = await Hash.load(keyData);
+      hash2.append(Uint8Array.from([1]));
+      let out1 = hash1.finalize64();
+      const out2 = hash2.finalize64();
+      let expected1 = Uint8Array.from([105, 68, 213, 185, 117, 218, 53, 112]);
+      let expected2 = Uint8Array.from([85, 188, 95, 74, 133, 192, 47, 84]);
+      expect(out1).toEqual(expected1);
+      expect(out2).toEqual(expected2);
+    });
   });
 }
 


### PR DESCRIPTION
This PR achieves significant gains by eschewing the need for Rust to include an allocator. Everything is handled statically. See this post for more information: https://nickb.dev/blog/avoiding-allocations-in-rust-to-shrink-wasm-modules/

I believe this to be a breaking change as there is a limit to the number of wasm hashing instances possible (292)

Closes #47
Closes #48 