### PR TITLE
Fix type definitions

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -25,7 +25,7 @@ const rolls = (fmt, platform, inline) => ({
           ? { maxFileSize: 0, targetEnv: "node" }
           : { targetEnv: "auto-inline" }
       ),
-    typescript({ outDir: outdir(fmt, platform, inline) }),
+    typescript({ outDir: outdir(fmt, platform, inline), rootDir: "src" }),
     {
       name: "custom",
       resolveImportMeta: () => `""`,


### PR DESCRIPTION
The file paths pointed to by package export `types` didn't exist. So this commit reinstates them.