### PR TITLE
Fix slim module typing and update output target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
       run: npm run test:inplace
     - name: browser test
       working-directory: ./tests/e2e
-      if: matrix.target == ''
+      if: matrix.build == 'linux-gnu'
       run: |
         npm install
         npm test

--- a/package.json
+++ b/package.json
@@ -12,28 +12,28 @@
   "module": "./dist/browser-fat/es/index_browser_fat.js",
   "exports": {
     ".": {
-      "types": "./dist/browser-fat/es/main/index_browser_fat.d.ts",
+      "types": "./dist/types/main/index_browser_fat.d.ts",
       "node-addons": {
-        "import": "./dist/node/es/index_node.js",
-        "default": "./dist/node/cjs/index_node.cjs"
+        "types": "./dist/types/main/index_node.d.ts",
+        "default": "./dist/node/index_node.cjs"
       },
       "import": "./dist/browser-fat/es/index_browser_fat.js",
-      "default": "./dist/browser-fat/cjs/index_browser_fat.js"
+      "default": "./dist/browser-fat/cjs/index_browser_fat.cjs"
     },
     "./slim": {
-      "types": "./dist/browser-slim/es/main/index_browser_fat.d.ts",
+      "types": "./dist/types/main/index_browser_slim.d.ts",
       "node-addons": {
-        "import": "./dist/node/es/index_node.js",
-        "default": "./dist/node/cjs/index_node.cjs"
+        "types": "./dist/types/main/index_node.d.ts",
+        "default": "./dist/node/index_node.cjs"
       },
       "import": "./dist/browser-slim/es/index_browser_slim.js",
-      "default": "./dist/browser-slim/cjs/index_browser_slim.js"
+      "default": "./dist/browser-slim/cjs/index_browser_slim.cjs"
     },
     "./sisd.wasm": "./dist/highwayhasher_wasm_bg.wasm",
     "./simd.wasm": "./dist/highwayhasher_wasm_simd_bg.wasm",
     "./package.json": "./package.json"
   },
-  "types": "./dist/browser-fat/es/main/index_browser_fat.d.ts",
+  "types": "./dist/types/main/index_browser_fat.d.ts",
   "files": [
     "dist"
   ],
@@ -48,7 +48,7 @@
     "optimize": "wasm-opt -Os src/main/wasm/highwayhasher_wasm_bg.wasm -o tmp.wasm && mv tmp.wasm src/main/wasm/highwayhasher_wasm_bg.wasm && wasm-opt -Os src/main/wasm-simd/highwayhasher_wasm_bg.wasm -o tmp.wasm && mv tmp.wasm src/main/wasm-simd/highwayhasher_wasm_bg.wasm",
     "test": "npm run build && npm run test:inplace",
     "test:inplace": "npm run test:native && npm run test:types",
-    "test:types": "tsc --outDir out",
+    "test:types": "tsc",
     "test:native": "vitest run --dir tests/unit",
     "prepublishOnly": "npm test && npm run optimize && ./assets/download-releases.sh && npm run build:bundle"
   },

--- a/src/main/index_browser_fat.ts
+++ b/src/main/index_browser_fat.ts
@@ -1,9 +1,9 @@
-export type { IHash, HashCreator, HighwayLoadOptions } from "./model";
-export { WasmHighwayHash, hasSimd as hasWasmSimd } from "./wasm";
-export { WasmHighwayHash as HighwayHash } from "./wasm";
+export type { IHash, HashCreator, HighwayLoadOptions } from "./model.js";
+export { WasmHighwayHash, hasSimd as hasWasmSimd } from "./wasm.js";
+export { WasmHighwayHash as HighwayHash } from "./wasm.js";
 import wasm from "./wasm/highwayhasher_wasm_bg.wasm";
 import wasmSimd from "./wasm-simd/highwayhasher_wasm_bg.wasm";
-import { setWasmInit, setWasmSimdInit } from "./wasm";
+import { setWasmInit, setWasmSimdInit } from "./wasm.js";
 
 // @ts-ignore
 setWasmInit(() => wasm());

--- a/src/main/index_browser_slim.ts
+++ b/src/main/index_browser_slim.ts
@@ -1,3 +1,3 @@
-export type { IHash, HashCreator, HighwayLoadOptions } from "./model";
-export { WasmHighwayHash, hasSimd as hasWasmSimd } from "./wasm";
-export { WasmHighwayHash as HighwayHash } from "./wasm";
+export type { IHash, HashCreator, HighwayLoadOptions } from "./model.js";
+export { WasmHighwayHash, hasSimd as hasWasmSimd } from "./wasm.js";
+export { WasmHighwayHash as HighwayHash } from "./wasm.js";

--- a/src/main/index_node.ts
+++ b/src/main/index_node.ts
@@ -1,9 +1,9 @@
-export type { IHash, HashCreator, HighwayLoadOptions } from "./model";
-export { WasmHighwayHash, hasSimd as hasWasmSimd } from "./wasm";
-export { NativeHighwayHash as HighwayHash } from "./native";
+export type { IHash, HashCreator, HighwayLoadOptions } from "./model.js";
+export { WasmHighwayHash, hasSimd as hasWasmSimd } from "./wasm.js";
+export { NativeHighwayHash as HighwayHash } from "./native.js";
 import wasm from "./wasm/highwayhasher_wasm_bg.wasm";
 import wasmSimd from "./wasm-simd/highwayhasher_wasm_bg.wasm";
-import { setWasmInit, setWasmSimdInit } from "./wasm";
+import { setWasmInit, setWasmSimdInit } from "./wasm.js";
 
 // @ts-ignore
 setWasmInit(() => wasm());

--- a/src/main/wasm.ts
+++ b/src/main/wasm.ts
@@ -4,8 +4,8 @@ import type {
   IHash,
   InitInput,
   WasmInput,
-} from "./model";
-import { validKey } from "./common";
+} from "./model.js";
+import { validKey } from "./common.js";
 import init, {
   new_hasher as newWasmHighway,
   append as sisdAppend,
@@ -51,7 +51,7 @@ export class WasmHighwayHash {
         return await loadWasmSimd(options?.wasm?.simd);
       }
     } else {
-      return await loadWasm(options.wasm);
+      return await loadWasm(options?.wasm);
     }
   }
 
@@ -191,7 +191,7 @@ let sisdMemory: Promise<HashCreator> | undefined;
 let simdMemory: Promise<HashCreator> | undefined;
 const loadWasmSimd = async (module?: InitInput) => {
   if (simdMemory === undefined) {
-    simdMemory = simdInit(module ?? wasmSimdInit()).then((x) => {
+    simdMemory = simdInit(module ?? wasmSimdInit?.()).then((x) => {
       const prevLength = x.memory.grow(1);
       const alloc = new Allocator(x.memory, prevLength);
       return wasmHighway(alloc, {
@@ -208,7 +208,7 @@ const loadWasmSimd = async (module?: InitInput) => {
 
 const loadWasm = async (module?: InitInput) => {
   if (sisdMemory === undefined) {
-    sisdMemory = init(module ?? wasmInit()).then((x) => {
+    sisdMemory = init(module ?? wasmInit?.()).then((x) => {
       // grow by 1 page to hold key, results, and data hashing
       const prevLength = x.memory.grow(1);
       const alloc = new Allocator(x.memory, prevLength);

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "pretest": "cp ../../out/tests/unit/hash.test.js .",
+    "pretest": "npx esbuild ../unit/hash.test.ts --external:fs --bundle --outfile=./hash.test.js",
     "test": "karmatic --coverage false hash.test.js",
     "posttest": "rm hash.test.js"
   },

--- a/tests/unit/hash.test.ts
+++ b/tests/unit/hash.test.ts
@@ -23,7 +23,7 @@ it("choose hash implementation depending on platform", () => {
   if (isNode()) {
     expect(HighwayHash.name).toEqual("NativeHighwayHash");
   } else {
-    expect(HighwayHash.name).toEqual("WasmHighwayHash");
+    expect(HighwayHash.name).toContain("WasmHighwayHash");
   }
 });
 
@@ -31,7 +31,7 @@ it("choose hash implementation depending on platform", () => {
 const parameters = [
   ["impl", HighwayHash],
   ["wasm", WasmHighwayHash],
-];
+] as const;
 
 for (let i = 0; i < parameters.length; i++) {
   const name = parameters[i][0];

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,30 +1,17 @@
 {
   "include": ["src", "tests"],
-  "exclude": ["node_modules"],
   "compilerOptions": {
-    "target": "ES2017",
+    "target": "ES2022",
+    "noEmit": true,
+    "module": "ES2022",
+    "lib": ["dom", "ES2022"],
     "types": ["vitest/globals"],
-    // what follows is from the tsdx project
-    "module": "esnext",
-    "lib": ["dom", "esnext"],
-    "importHelpers": true,
-    // output .d.ts declaration files for consumers
     "declaration": true,
-    // stricter type-checking for stronger correctness. Recommended by TS
-    // "strict": true,
-    // linter checks for common issues
-    "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": true,
-    // noUnused* overlap with @typescript-eslint/no-unused-vars, can disable if duplicative
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    // use Node's module resolution algorithm, instead of the legacy TS one
+    "declarationDir": "dist/types",
+    "strict": true,
     "moduleResolution": "node",
-    // interop between ESM and CJS modules. Recommended by TS
     "esModuleInterop": true,
-    // significant perf increase by skipping checking .d.ts files, particularly those in node_modules. Recommended by TS
     "skipLibCheck": true,
-    // error out if import and file system have a casing mismatch. Recommended by TS
     "forceConsistentCasingInFileNames": true
   }
 }


### PR DESCRIPTION
- Correctly author ESM types for `/slim` users
- Bump target of output destined for bundlers to ES2022
- Remove node ESM output as it mixes require and imports