### PR TITLE
Update to rollup-wasm v6.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "build:native": "bash ./assets/build-native.sh",
     "build:wasm": "wasm-pack build -t web --out-dir ../main/wasm src/wasm",
     "build:wasm-simd": "RUSTFLAGS='-C target-feature=+simd128' npm run build:wasm-simd-ci",
-    "build:wasm-simd-ci": "wasm-pack build -t web --out-dir ../main/wasm-simd src/wasm",
+    "build:wasm-simd-ci": "wasm-pack build -t web --out-name highwayhasher_wasm_simd --out-dir ../main/wasm-simd src/wasm",
     "build:bundle": "rollup -c --bundleConfigAsCjs",
     "compressed-size": "npm run build && find dist -iname '*.js' -exec npx terser@latest --compress --mangle --output {} -- {} \\;",
     "optimize": "wasm-opt -Os src/main/wasm/highwayhasher_wasm_bg.wasm -o tmp.wasm && mv tmp.wasm src/main/wasm/highwayhasher_wasm_bg.wasm && wasm-opt --enable-simd -Os src/main/wasm-simd/highwayhasher_wasm_bg.wasm -o tmp.wasm && mv tmp.wasm src/main/wasm-simd/highwayhasher_wasm_bg.wasm",
@@ -62,7 +62,7 @@
   "license": "MIT",
   "devDependencies": {
     "@rollup/plugin-typescript": "^10.0.1",
-    "@rollup/plugin-wasm": "^6.0.1",
+    "@rollup/plugin-wasm": "^6.1.1",
     "@types/node": "^18.11.11",
     "rollup": "^3.6.0",
     "tslib": "^2.4.1",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -29,7 +29,12 @@ const rolls = (fmt, platform, inline) => ({
     inline !== "slim" &&
       wasm(
         platform === "node"
-          ? { maxFileSize: 0, targetEnv: "node", publicPath: "../" }
+        ? {
+          maxFileSize: 0,
+          targetEnv: "node",
+          publicPath: "../",
+          fileName: "[name][extname]",
+        }
           : { targetEnv: "auto-inline" }
       ),
     typescript({
@@ -46,18 +51,6 @@ const rolls = (fmt, platform, inline) => ({
             recursive: true,
           });
           distributeSharedNode();
-
-          // Copy over our wasm bundles to each out directory as a known name to
-          // downstream users so that they can access the wasm payloads directly
-          // as needed.
-          fs.copyFileSync(
-            "src/main/wasm/highwayhasher_wasm_bg.wasm",
-            "dist/highwayhasher_wasm_bg.wasm"
-          );
-          fs.copyFileSync(
-            "src/main/wasm-simd/highwayhasher_wasm_bg.wasm",
-            "dist/highwayhasher_wasm_simd_bg.wasm"
-          );
         }
       },
     },

--- a/src/main/index_browser_fat.ts
+++ b/src/main/index_browser_fat.ts
@@ -2,7 +2,7 @@ export type { IHash, HashCreator, HighwayLoadOptions } from "./model.js";
 export { WasmHighwayHash, hasSimd as hasWasmSimd } from "./wasm.js";
 export { WasmHighwayHash as HighwayHash } from "./wasm.js";
 import wasm from "./wasm/highwayhasher_wasm_bg.wasm";
-import wasmSimd from "./wasm-simd/highwayhasher_wasm_bg.wasm";
+import wasmSimd from "./wasm-simd/highwayhasher_wasm_simd_bg.wasm";
 import { setWasmInit, setWasmSimdInit } from "./wasm.js";
 
 // @ts-ignore

--- a/src/main/index_node.ts
+++ b/src/main/index_node.ts
@@ -2,7 +2,7 @@ export type { IHash, HashCreator, HighwayLoadOptions } from "./model.js";
 export { WasmHighwayHash, hasSimd as hasWasmSimd } from "./wasm.js";
 export { NativeHighwayHash as HighwayHash } from "./native.js";
 import wasm from "./wasm/highwayhasher_wasm_bg.wasm";
-import wasmSimd from "./wasm-simd/highwayhasher_wasm_bg.wasm";
+import wasmSimd from "./wasm-simd/highwayhasher_wasm_simd_bg.wasm";
 import { setWasmInit, setWasmSimdInit } from "./wasm.js";
 
 // @ts-ignore

--- a/src/main/wasm.ts
+++ b/src/main/wasm.ts
@@ -19,7 +19,7 @@ import simdInit, {
   finalize64 as simdFinalize64,
   finalize128 as simdFinalize128,
   finalize256 as simdFinalize256,
-} from "./wasm-simd/highwayhasher_wasm";
+} from "./wasm-simd/highwayhasher_wasm_simd";
 
 let wasmInit: (() => InitInput) | undefined = undefined;
 export const setWasmInit = (arg: () => InitInput) => {

--- a/tests/unit/hash.test.ts
+++ b/tests/unit/hash.test.ts
@@ -177,7 +177,8 @@ if (!hasWasmSimd() && isNode()) {
 if (isNode()) {
   it("should accept wasm module", async () => {
     const { readFile } = require("fs").promises;
-    const wasmData = await readFile("src/main/wasm/highwayhasher_wasm_bg.wasm");
+    const pkg = require("highwayhasher/package.json");
+    const wasmData = await readFile(pkg.exports["./sisd.wasm"]);
     const module = new WebAssembly.Module(wasmData);
     const mod = await WasmHighwayHash.loadModule({ wasm: module });
     const hash = mod.create();
@@ -188,10 +189,9 @@ if (isNode()) {
 
   it("should accept wasm module object", async () => {
     const { readFile } = require("fs").promises;
-    const sisdData = await readFile("src/main/wasm/highwayhasher_wasm_bg.wasm");
-    const simdData = await readFile(
-      "src/main/wasm-simd/highwayhasher_wasm_bg.wasm"
-    );
+    const pkg = require("highwayhasher/package.json");
+    const sisdData = await readFile(pkg.exports["./sisd.wasm"]);
+    const simdData = await readFile(pkg.exports["./simd.wasm"]);
     const mod = await WasmHighwayHash.loadModule({
       wasm: {
         sisd: sisdData,


### PR DESCRIPTION
With the new `fileName` config option, we now longer need to copy the wasm to a known location.