### PR TITLE
Fix native hashing on arm macs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,10 +26,9 @@ jobs:
         - build: win-msvc
           os: windows-latest
         - build: macos
-          os: macos-11
+          os: macos-12
         - build: macos-aarch64
-          os: macos-11
-          target: aarch64-apple-darwin
+          os: macos-14
         - build: linux-gnu
           os: ubuntu-latest
         - build: linux-aarch64
@@ -57,7 +56,7 @@ jobs:
       with:
         node-version: ${{ matrix.node }}
     - name: Install wasm-pack
-      run:  npm install -g wasm-pack@0.10.1
+      run:  npm install -g wasm-pack@0.12.1
     - run: npm install
     - name: build wasm-simd
       shell: bash

--- a/src/main/native.ts
+++ b/src/main/native.ts
@@ -13,7 +13,7 @@ const getTriple = (): string => {
     return "armv7-unknown-linux-gnueabihf";
   } else if (platform === "darwin" && arch === "x64") {
     return "x86_64-apple-darwin";
-  } else if (platform === "darwin" && arch === "arm") {
+  } else if (platform === "darwin" && arch === "arm64") {
     return "aarch64-apple-darwin";
   } else if (platform === "win32" && arch == "x64") {
     return "x86_64-pc-windows-msvc";


### PR DESCRIPTION
- Use native m1 mac github action environment
- Required bumping wasm-pack to latest to support m1 macs